### PR TITLE
Stackage update

### DIFF
--- a/src/Pantry/Internal/Stackage.hs
+++ b/src/Pantry/Internal/Stackage.hs
@@ -29,6 +29,7 @@ import Pantry.Storage as X
   , getTreeForKey
   , getVersionId
   , loadBlobById
+  , storeBlob
   , allBlobsSource
   , allBlobsCount
   , allHackageCabalCount

--- a/src/Pantry/Internal/Stackage.hs
+++ b/src/Pantry/Internal/Stackage.hs
@@ -17,7 +17,6 @@ import Pantry.Storage as X
   , PackageName
   , PackageNameId
   , Tree(..)
-  , TreeEntry(..)
   , TreeEntryId
   , TreeId
   , Unique(..)
@@ -30,12 +29,7 @@ import Pantry.Storage as X
   , getVersionId
   , loadBlobById
   , storeBlob
-  , allBlobsSource
-  , allBlobsCount
-  , allHackageCabalCount
-  , allHackageCabalRawPackageLocations
   , migrateAll
-  , treeCabal
   , Key(unBlobKey)
   )
 import Pantry.Types as X
@@ -46,11 +40,6 @@ import Pantry.Types as X
   , Storage(..)
   , VersionP(..)
   , mkSafeFilePath
-  , packageNameString
   , packageTreeKey
-  , parsePackageName
-  , parseVersion
-  , parseVersionThrowing
   , unSafeFilePath
-  , versionString
   )


### PR DESCRIPTION
These are the changes necessary for the new upcoming PR into stackage that adds ability to use fallback cabal files for core packages from external repo: [commercialhaskell/core-cabal-files](https://github.com/commercialhaskell/core-cabal-files)