### PR TITLE
Make snapshot locations configurable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for pantry
 
+## v0.5.0.0
+
+* Make the location of LTS/Nightly snapshots configurable
+
 ## v0.4.0.1
 
 * Removed errant log message

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        pantry
-version:     0.4.0.1
+version:     0.5.0.0
 synopsis:    Content addressable Haskell package management
 description: Please see the README on Github at <https://github.com/commercialhaskell/pantry#readme>
 category:    Development

--- a/pantry.cabal
+++ b/pantry.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ce880f32030c524a97504445e34d07894a13fae3a9f59fe39fdbb48108eaad70
+-- hash: 863df22df50d6ec75b77b8b8898605fca1138f318854136ef154a9b5387f3d30
 
 name:           pantry
-version:        0.4.0.1
+version:        0.5.0.0
 synopsis:       Content addressable Haskell package management
 description:    Please see the README on Github at <https://github.com/commercialhaskell/pantry#readme>
 category:       Development

--- a/src/Pantry.hs
+++ b/src/Pantry.hs
@@ -26,6 +26,7 @@ module Pantry
   , hpackExecutableL
 
     -- * Types
+  , P.ResolveData (..)
 
     -- ** Exceptions
   , PantryException (..)
@@ -1417,12 +1418,12 @@ loadRawSnapshotLayer rsl@(RSLUrl url blob) =
   handleAny (throwIO . InvalidSnapshot rsl) $ do
     bs <- loadFromURL url blob
     value <- Yaml.decodeThrow bs
-    snapshot <- warningsParserHelperRaw rsl value Nothing
+    snapshot <- warningsParserHelperRaw rsl value mempty
     pure $ Right (snapshot, (CompletedSL rsl (SLUrl url (bsToBlobKey bs))))
 loadRawSnapshotLayer rsl@(RSLFilePath fp) =
   handleAny (throwIO . InvalidSnapshot rsl) $ do
     value <- Yaml.decodeFileThrow $ toFilePath $ resolvedAbsolute fp
-    snapshot <- warningsParserHelperRaw rsl value $ Just $ parent $ resolvedAbsolute fp
+    snapshot <- warningsParserHelperRaw rsl value $ ResolveData (Just $ parent $ resolvedAbsolute fp) Nothing
     pure $ Right (snapshot, CompletedSL rsl (SLFilePath fp))
 
 -- | Parse a 'SnapshotLayer' value from a 'SnapshotLocation'.
@@ -1441,12 +1442,12 @@ loadSnapshotLayer sl@(SLUrl url blob) =
   handleAny (throwIO . InvalidSnapshot (toRawSL sl)) $ do
     bs <- loadFromURL url (Just blob)
     value <- Yaml.decodeThrow bs
-    snapshot <- warningsParserHelper sl value Nothing
+    snapshot <- warningsParserHelper sl value mempty
     pure $ Right snapshot
 loadSnapshotLayer sl@(SLFilePath fp) =
   handleAny (throwIO . InvalidSnapshot (toRawSL sl)) $ do
     value <- Yaml.decodeFileThrow $ toFilePath $ resolvedAbsolute fp
-    snapshot <- warningsParserHelper sl value $ Just $ parent $ resolvedAbsolute fp
+    snapshot <- warningsParserHelper sl value $ ResolveData (Just $ parent $ resolvedAbsolute fp) Nothing
     pure $ Right snapshot
 
 loadFromURL
@@ -1502,31 +1503,31 @@ warningsParserHelperRaw
   :: HasLogFunc env
   => RawSnapshotLocation
   -> Value
-  -> Maybe (Path Abs Dir)
+  -> ResolveData
   -> RIO env RawSnapshotLayer
-warningsParserHelperRaw rsl val mdir =
+warningsParserHelperRaw rsl val res =
   case parseEither Yaml.parseJSON val of
     Left e -> throwIO $ Couldn'tParseSnapshot rsl e
     Right (WithJSONWarnings x ws) -> do
       unless (null ws) $ do
         logWarn $ "Warnings when parsing snapshot " <> display rsl
         for_ ws $ logWarn . display
-      resolvePaths mdir x
+      resolvePaths res x
 
 warningsParserHelper
   :: HasLogFunc env
   => SnapshotLocation
   -> Value
-  -> Maybe (Path Abs Dir)
+  -> ResolveData
   -> RIO env RawSnapshotLayer
-warningsParserHelper sl val mdir =
+warningsParserHelper sl val res =
   case parseEither Yaml.parseJSON val of
     Left e -> throwIO $ Couldn'tParseSnapshot (toRawSL sl) e
     Right (WithJSONWarnings x ws) -> do
       unless (null ws) $ do
         logWarn $ "Warnings when parsing snapshot " <> display sl
         for_ ws $ logWarn . display
-      resolvePaths mdir x
+      resolvePaths res x
 
 -- | Get the 'PackageName' of the package at the given location.
 --

--- a/src/Pantry.hs
+++ b/src/Pantry.hs
@@ -114,6 +114,7 @@ module Pantry
 
     -- * Parsers
   , parseWantedCompiler
+  , parseSnapName
   , parseRawSnapshotLocation
   , parsePackageIdentifierRevision
   , parseHackageText

--- a/src/Pantry/Types.hs
+++ b/src/Pantry/Types.hs
@@ -273,8 +273,10 @@ data ResolveData = ResolveData
     -- version identifiers.
     -- If @Just url@ is provided, then:
     --   * "lts-X.Y" resolves to "url/lts/X/Y.yaml"
-    --   * "nightly-YYYY-MM-DD" resolves to "nightly/YYYY/MM/DD.yaml"
-    -- Note: @url@ must not end with a trailing @/@.
+    --       (see 'ltsSnapshotLocation')
+    --   * "nightly-YYYY-MM-DD" resolves to "url/nightly/YYYY/MM/DD.yaml"
+    --      (see 'nightlySnapshotLocation')
+    -- Note: @url@ must not contain a trailing @/@.
     --
     -- @since TODO:
   }

--- a/src/Pantry/Types.hs
+++ b/src/Pantry/Types.hs
@@ -258,7 +258,7 @@ data PantryConfig = PantryConfig
 
 -- | Get the location of a snapshot synonym from the 'PantryConfig'.
 --
--- @since TODO:
+-- @since 0.5.0.0
 snapshotLocation :: HasPantryConfig env => SnapName -> RIO env RawSnapshotLocation
 snapshotLocation name = do
   loc <- view $ pantryConfigL.to pcSnapshotLocation
@@ -1912,7 +1912,7 @@ defRepo = "stackage-snapshots"
 -- | Default location of snapshot synonyms
 -- , i.e. commercialhaskell's GitHub repository.
 --
--- @since TODO:
+-- @since 0.5.0.0
 defaultSnapshotLocation
   :: SnapName
   -> RawSnapshotLocation
@@ -1931,19 +1931,19 @@ defaultSnapshotLocation (Nightly date) =
 -- It is expanded according to the field 'snapshotLocation'
 -- of a 'PantryConfig'.
 --
--- @ since TODO:
+-- @ since 0.5.0.0
 data SnapName
     -- | LTS Haskell snapshot,
     -- displayed as @"lts-maj.min"@.
     --
-    -- @since TODO:
+    -- @since 0.5.0.0
     = LTS
         !Int -- ^ Major version 
         !Int -- ^ Minor version
     -- | Stackage Nightly snapshot,
     -- displayed as @"nighly-YYYY-MM-DD"@.
     --
-    -- @since TODO:
+    -- @since 0.5.0.0
     | Nightly !Day
     deriving (Eq, Ord, Generic)
 
@@ -1961,7 +1961,7 @@ instance ToJSON SnapName where
 
 -- | Parse the short representation of a 'SnapName'.
 --
--- @since TODO:
+-- @since 0.5.0.0
 parseSnapName :: MonadThrow m => Text -> m SnapName
 parseSnapName t0 =
     case lts <|> nightly of
@@ -2000,7 +2000,7 @@ data RawSnapshotLocation
   | RSLSynonym !SnapName
     -- ^ Snapshot synonym (LTS/Nightly).
     --
-    -- @since TODO:
+    -- @since 0.5.0.0
   deriving (Show, Eq, Ord, Generic)
 
 instance NFData RawSnapshotLocation

--- a/src/Pantry/Types.hs
+++ b/src/Pantry/Types.hs
@@ -255,7 +255,7 @@ data PantryConfig = PantryConfig
   -- ^ The location of snapshot synonyms
   }
 
--- | Get the location of a snapshot synonym from a 'PantryConfig'.
+-- | Get the location of a snapshot synonym from the 'PantryConfig'.
 --
 -- @since TODO:
 snapshotLocation :: HasPantryConfig env => SnapName -> RIO env RawSnapshotLocation
@@ -2007,7 +2007,6 @@ instance ToJSON RawSnapshotLocation where
     : maybe [] blobKeyPairs mblob
   toJSON (RSLFilePath resolved) = object ["filepath" .= resolvedRelative resolved]
   toJSON (RSLSynonym syn) = toJSON syn
-  -- to
 
 -- | Where to load a snapshot from.
 --

--- a/test/Pantry/BuildPlanSpec.hs
+++ b/test/Pantry/BuildPlanSpec.hs
@@ -24,7 +24,7 @@ spec =
             decode'' bs = do
               WithJSONWarnings unresolved warnings <- decode' bs
               unless (null warnings) $ error $ show warnings
-              resolvePaths mempty unresolved
+              resolvePaths Nothing unresolved
 
         it "'github' and 'commit' keys" $ do
           let contents :: ByteString

--- a/test/Pantry/BuildPlanSpec.hs
+++ b/test/Pantry/BuildPlanSpec.hs
@@ -24,7 +24,7 @@ spec =
             decode'' bs = do
               WithJSONWarnings unresolved warnings <- decode' bs
               unless (null warnings) $ error $ show warnings
-              resolvePaths Nothing unresolved
+              resolvePaths mempty unresolved
 
         it "'github' and 'commit' keys" $ do
           let contents :: ByteString

--- a/test/Pantry/TypesSpec.hs
+++ b/test/Pantry/TypesSpec.hs
@@ -114,13 +114,13 @@ spec = do
       RawSnapshotLayer{..} <- parseSl $
         "name: 'test'\n" ++
         "resolver: lts-2.10\n"
-      rslParent `shouldBe` RSLLTS 2 10
+      rslParent `shouldBe` (RSLSynonym $ LTS 2 10)
 
     it "parses snapshot using 'snapshot'" $ do
       RawSnapshotLayer{..} <- parseSl $
         "name: 'test'\n" ++
         "snapshot: lts-2.10\n"
-      rslParent `shouldBe` RSLLTS 2 10
+      rslParent `shouldBe` (RSLSynonym $ LTS 2 10)
 
     it "throws if both 'resolver' and 'snapshot' are present" $ do
       let go = parseSl $
@@ -145,14 +145,14 @@ spec = do
         <$> Gen.integral (Range.linear 1 10000)
         <*> Gen.integral (Range.linear 1 10000)
       liftIO $
-        Yaml.toJSON (RSLLTS major minor) `shouldBe`
+        Yaml.toJSON (RSLSynonym $ LTS major minor) `shouldBe`
         Yaml.String (T.pack $ concat ["lts-", show major, ".", show minor])
 
     hh "rendering a nightly gives a nice name" $ property $ do
       days <- forAll $ Gen.integral $ Range.linear 1 10000000
       let day = ModifiedJulianDay days
       liftIO $
-        Yaml.toJSON (RSLNightly day) `shouldBe`
+        Yaml.toJSON (RSLSynonym $ Nightly day) `shouldBe`
         Yaml.String (T.pack $ "nightly-" ++ show day)
     it "FromJSON instance for PLIRepo" $ do
       WithJSONWarnings unresolvedPli warnings <- Yaml.decodeThrow samplePLIRepo

--- a/test/Pantry/TypesSpec.hs
+++ b/test/Pantry/TypesSpec.hs
@@ -107,20 +107,22 @@ spec = do
   describe "(Raw)SnapshotLayer" $ do
     let parseSl :: String -> IO RawSnapshotLayer
         parseSl str = case Yaml.decodeThrow . S8.pack $ str of
-          (Just (WithJSONWarnings x _)) -> resolvePaths Nothing x
+          (Just (WithJSONWarnings x _)) -> resolvePaths mempty x
           Nothing -> fail "Can't parse RawSnapshotLayer"
 
     it "parses snapshot using 'resolver'" $ do
       RawSnapshotLayer{..} <- parseSl $
         "name: 'test'\n" ++
         "resolver: lts-2.10\n"
-      rslParent `shouldBe` ltsSnapshotLocation 2 10
+      expected <- resolvePaths mempty $ ltsSnapshotLocation 2 10
+      rslParent `shouldBe` expected
 
     it "parses snapshot using 'snapshot'" $ do
       RawSnapshotLayer{..} <- parseSl $
         "name: 'test'\n" ++
         "snapshot: lts-2.10\n"
-      rslParent `shouldBe` ltsSnapshotLocation 2 10
+      expected <- resolvePaths mempty $ ltsSnapshotLocation 2 10
+      rslParent `shouldBe` expected
 
     it "throws if both 'resolver' and 'snapshot' are present" $ do
       let go = parseSl $
@@ -143,20 +145,22 @@ spec = do
       (major, minor) <- forAll $ (,)
         <$> Gen.integral (Range.linear 1 10000)
         <*> Gen.integral (Range.linear 1 10000)
-      liftIO $
-        Yaml.toJSON (ltsSnapshotLocation major minor) `shouldBe`
-        Yaml.String (T.pack $ concat ["lts-", show major, ".", show minor])
+      liftIO $ do
+        gen <- resolvePaths mempty $ ltsSnapshotLocation major minor
+        Yaml.toJSON gen `shouldBe`
+          Yaml.String (T.pack $ concat ["lts-", show major, ".", show minor])
 
     hh "rendering a nightly gives a nice name" $ property $ do
       days <- forAll $ Gen.integral $ Range.linear 1 10000000
       let day = ModifiedJulianDay days
-      liftIO $
-        Yaml.toJSON (nightlySnapshotLocation day) `shouldBe`
-        Yaml.String (T.pack $ "nightly-" ++ show day)
+      liftIO $ do
+        gen <- resolvePaths mempty $ nightlySnapshotLocation day
+        Yaml.toJSON gen `shouldBe`
+          Yaml.String (T.pack $ "nightly-" ++ show day)
     it "FromJSON instance for PLIRepo" $ do
       WithJSONWarnings unresolvedPli warnings <- Yaml.decodeThrow samplePLIRepo
       warnings `shouldBe` []
-      pli <- resolvePaths Nothing unresolvedPli
+      pli <- resolvePaths mempty unresolvedPli
       let repoValue =
               Repo
                   { repoSubdir = "wai"
@@ -183,7 +187,7 @@ spec = do
 
       WithJSONWarnings reparsed warnings2 <- Yaml.decodeThrow $ Yaml.encode pli
       warnings2 `shouldBe` []
-      reparsed' <- resolvePaths Nothing reparsed
+      reparsed' <- resolvePaths mempty reparsed
       reparsed' `shouldBe` pli
     it "parseHackageText parses" $ do
       let txt =
@@ -203,8 +207,8 @@ spec = do
     it "roundtripping a PLIRepo" $ do
       WithJSONWarnings unresolvedPli warnings <- Yaml.decodeThrow samplePLIRepo2
       warnings `shouldBe` []
-      pli <- resolvePaths Nothing unresolvedPli
+      pli <- resolvePaths mempty unresolvedPli
       WithJSONWarnings unresolvedPli2 warnings2 <- Yaml.decodeThrow $ Yaml.encode pli
       warnings2 `shouldBe` []
-      pli2 <- resolvePaths Nothing unresolvedPli2
+      pli2 <- resolvePaths mempty unresolvedPli2
       pli2 `shouldBe` (pli :: PackageLocationImmutable)

--- a/test/Pantry/TypesSpec.hs
+++ b/test/Pantry/TypesSpec.hs
@@ -114,13 +114,13 @@ spec = do
       RawSnapshotLayer{..} <- parseSl $
         "name: 'test'\n" ++
         "resolver: lts-2.10\n"
-      rslParent `shouldBe` ltsSnapshotLocation 2 10
+      rslParent `shouldBe` RSLLTS 2 10
 
     it "parses snapshot using 'snapshot'" $ do
       RawSnapshotLayer{..} <- parseSl $
         "name: 'test'\n" ++
         "snapshot: lts-2.10\n"
-      rslParent `shouldBe` ltsSnapshotLocation 2 10
+      rslParent `shouldBe` RSLLTS 2 10
 
     it "throws if both 'resolver' and 'snapshot' are present" $ do
       let go = parseSl $
@@ -139,19 +139,20 @@ spec = do
         "compiler: ghc-8.0.1\n"
       rslParent `shouldBe` RSLCompiler (WCGhc (mkVersion [8, 0, 1]))
 
+    -- TODO: Remove the following two tests, and add more
     hh "rendering an LTS gives a nice name" $ property $ do
       (major, minor) <- forAll $ (,)
         <$> Gen.integral (Range.linear 1 10000)
         <*> Gen.integral (Range.linear 1 10000)
       liftIO $
-        Yaml.toJSON (ltsSnapshotLocation major minor) `shouldBe`
+        Yaml.toJSON (RSLLTS major minor) `shouldBe`
         Yaml.String (T.pack $ concat ["lts-", show major, ".", show minor])
 
     hh "rendering a nightly gives a nice name" $ property $ do
       days <- forAll $ Gen.integral $ Range.linear 1 10000000
       let day = ModifiedJulianDay days
       liftIO $
-        Yaml.toJSON (nightlySnapshotLocation day) `shouldBe`
+        Yaml.toJSON (RSLNightly day) `shouldBe`
         Yaml.String (T.pack $ "nightly-" ++ show day)
     it "FromJSON instance for PLIRepo" $ do
       WithJSONWarnings unresolvedPli warnings <- Yaml.decodeThrow samplePLIRepo


### PR DESCRIPTION
**Description of the problem**
`pantry` expands snapshot synonyms (like `lts-X.Y` or `nightly-YYYY-MM-DD`) to a URL, using the hardcoded address of  commercialhaskell's git repository.

This basically happens in the functions `ltsSnapshotLocation` and `nightlySnapshotLocation` in [Types.hs](https://github.com/commercialhaskell/pantry/blob/master/src/Pantry/Types.hs). For instance, `lts-X.Y` expands to `https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/X/Y.yaml`.

The hardcoded URL, however, prevents to use mirrors for snapshot locations, and mirrors are necessary in corporate environments (or really anywhere behind a firewall).

(Note: one could specify a custom URL instead of a snapshot synonym, but this can be undesirable for the following reason. In a corporate environment, it's common that the development environment has unrestricted access to the internet, but test/production servers have not. If the base location of snapshots is configurable, a project can still use the familiar snapshot synonyms, and just let the environment change the location accordingly.)


**Description of the proposed solution**
In the `Types.hs` file, is already present a mechanism to resolve relative (local) paths by means of the `Unresolved` type constructor. `Unresolved` means that such an object could contain relative paths, and a base path is required to resolve them to absolute paths.

My proposal is to extend `Unresolved` with an additional optional URL field, the URL being the supplied base location of the snapshots. I refactored `Unresolved` to follow the state monad pattern, and this minimised the changes. To resolve paths, one supplies an object of type `ResolveData`, which combines the old base directory, and the new base location of snapshots. 

This changes a bit the API, and that's where I wanted to hear from the maintainers.
The main change of course is in `ltsSnapshotLocation` and `nightlySnapshotLocation`, which return a `Unresolved RawSnapshotLocation`, but there are a few more altered type signatures (clearly `resolvePaths`, but also `warningsParserHelperRaw` and `warningsParserHelper`).

Also, it will be necessary to add a new entry to `PantryConfig`, so that the custom snapshot location is available to `loadSnapshotRaw` and `loadAndCompleteSnapshotRaw`, and as a consequence change the signature of `loadRawSnapshotLayer`. But first I wanted to hear from you.

**Additional context**
Closes #19.