### PR TITLE
Allow building with Cabal-3.2.*

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ dependencies:
 - persistent
 - persistent-sqlite >= 2.9.3
 - persistent-template
-- Cabal >= 3 && < 3.1
+- Cabal >= 3 && < 3.3
 - path-io
 - rio-orphans
 - conduit-extra

--- a/pantry.cabal
+++ b/pantry.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ce880f32030c524a97504445e34d07894a13fae3a9f59fe39fdbb48108eaad70
+-- hash: 9b1c222081658a1a186751c72f267247fb4f00c05807c74f77e88253fedbe020
 
 name:           pantry
 version:        0.4.0.1
@@ -55,7 +55,7 @@ library
       src/
   ghc-options: -Wall
   build-depends:
-      Cabal >=3 && <3.1
+      Cabal >=3 && <3.3
     , aeson
     , ansi-terminal
     , base >=4.10 && <5
@@ -133,7 +133,7 @@ test-suite spec
       test
   ghc-options: -Wall
   build-depends:
-      Cabal >=3 && <3.1
+      Cabal >=3 && <3.3
     , QuickCheck
     , aeson
     , ansi-terminal

--- a/src/Pantry/Tree.hs
+++ b/src/Pantry/Tree.hs
@@ -52,7 +52,7 @@ rawParseGPD
   -> m ([PWarning], GenericPackageDescription)
 rawParseGPD loc bs =
     case eres of
-      Left (mversion, errs) -> throwM $ InvalidCabalFile loc mversion errs warnings
+      Left (mversion, errs) -> throwM $ InvalidCabalFile loc mversion (toList errs) warnings
       Right gpkg -> return (warnings, gpkg)
   where
     (warnings, eres) = runParseResult $ parseGenericPackageDescription bs


### PR DESCRIPTION
The only API change in `Cabal-3.2.*` that affects `pantry` is the new type signature for `runParseResult`:

```diff
-runParseResult :: ParseResult a -> ([PWarning], Either (Maybe Version, [PError])        a)
+runParseResult :: ParseResult a -> ([PWarning], Either (Maybe Version, NonEmpty PError) a)
```

Luckily, this can be adapted to without CPP by simply calling `Foldable.toList` on the returned list of `PError`s, which works on both `[]` on `NonEmpty`.

Fixes #21.