### PR TITLE
Switch back to hackage.haskell.org

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog for pantry
 
+## v0.5.1.5
+* Switch back to hackage.haskell.org [#30](https://github.com/commercialhaskell/pantry/pull/30)
+
 ## v0.5.1.4
 
 * Allow building with persistent-2.11 [#28](https://github.com/commercialhaskell/pantry/pull/28)

--- a/src/Pantry.hs
+++ b/src/Pantry.hs
@@ -295,7 +295,7 @@ defaultHackageSecurityConfig = HackageSecurityConfig
       , "fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0"
       ]
   , hscKeyThreshold = 3
-  , hscDownloadPrefix = "https://s3.amazonaws.com/hackage.fpcomplete.com/"
+  , hscDownloadPrefix = "https://hackage.haskell.org/"
   , hscIgnoreExpiry = False
   }
 


### PR DESCRIPTION
's3.amazonaws.com' is not meant to serve clients around the world, as it
is hosted in the US only. This causes bandwidth to be severely throttled
for non-US users. This has been observed by users in
the following issue:

  https://github.com/commercialhaskell/stack/issues/2240

At some periods, bandwidth drops to effectively zero, rendering Stack
unusable. Measurements can be found here:

  https://github.com/commercialhaskell/stack/issues/2240#issuecomment-761197177

'hackage.haskell.org' is served from Fastly's CDN, therefore mitigating
these issues.

-----------------

This is part of a [larger effort](https://github.com/commercialhaskell/stack/issues/2240#issuecomment-761812803) to eliminate Stack's reliance on non-CDN resources :). I see @snoyberg reverted an earlier change to move back to hackage.haskell.org, perhaps he could comment on this issue?