### PR TITLE
Fix compatibility with GHC 9

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for pantry
 
+## v0.5.2.3
+
+* Support for GHC 9 [#39](https://github.com/commercialhaskell/pantry/pull/39)
+
 ## v0.5.2.2
 
 * Support for Cabal 3.4 [#38](https://github.com/commercialhaskell/pantry/pull/38)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        pantry
-version:     0.5.2.2
+version:     0.5.2.3
 synopsis:    Content addressable Haskell package management
 description: Please see the README on Github at <https://github.com/commercialhaskell/pantry#readme>
 category:    Development

--- a/pantry.cabal
+++ b/pantry.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: 290314cf42f0f169e5cb395c4b35e867438c4e2652df972ec59c548dc39f1b6d
 
 name:           pantry
-version:        0.5.2.2
+version:        0.5.2.3
 synopsis:       Content addressable Haskell package management
 description:    Please see the README on Github at <https://github.com/commercialhaskell/pantry#readme>
 category:       Development

--- a/src/Pantry/Storage.hs
+++ b/src/Pantry/Storage.hs
@@ -271,8 +271,9 @@ withStorage
   :: (HasPantryConfig env, HasLogFunc env)
   => ReaderT SqlBackend (RIO env) a
   -> RIO env a
-withStorage action =
-  flip (\x y -> SQLite.withStorage_ x y) action =<< view (P.pantryConfigL.to P.pcStorage)
+withStorage action = do
+  storage <- view (P.pantryConfigL.to P.pcStorage)
+  SQLite.withStorage_ storage action
 
 -- | This is a helper type to distinguish db queries between different rdbms backends. The important
 -- part is that the affects described in this data type should be semantically equivalent between

--- a/src/Pantry/Storage.hs
+++ b/src/Pantry/Storage.hs
@@ -272,7 +272,7 @@ withStorage
   => ReaderT SqlBackend (RIO env) a
   -> RIO env a
 withStorage action =
-  flip SQLite.withStorage_ action =<< view (P.pantryConfigL.to P.pcStorage)
+  flip (\x y -> SQLite.withStorage_ x y) action =<< view (P.pantryConfigL.to P.pcStorage)
 
 -- | This is a helper type to distinguish db queries between different rdbms backends. The important
 -- part is that the affects described in this data type should be semantically equivalent between


### PR DESCRIPTION
Fixes the following error:

```
[10 of 19] Compiling Pantry.Storage   ( src/Pantry/Storage.hs, dist/build/Pantry/Storage.dyn_o )

src/Pantry/Storage.hs:275:8: error:
    • Couldn't match type: forall env1 a1.
                           HasLogFunc env1 =>
                           ReaderT SqlBackend (RIO env1) a1 -> RIO env1 a1
                     with: ReaderT SqlBackend (RIO env) a -> RIO env a
      Expected: SQLite.Storage
                -> ReaderT SqlBackend (RIO env) a -> RIO env a
        Actual: SQLite.Storage
                -> forall env a.
                   HasLogFunc env =>
                   ReaderT SqlBackend (RIO env) a -> RIO env a
    • In the first argument of ‘flip’, namely ‘SQLite.withStorage_’
      In the first argument of ‘(=<<)’, namely
        ‘flip SQLite.withStorage_ action’
      In the expression:
        flip SQLite.withStorage_ action
          =<< view (P.pantryConfigL . to P.pcStorage)
    • Relevant bindings include
        action :: ReaderT SqlBackend (RIO env) a
          (bound at src/Pantry/Storage.hs:274:13)
        withStorage :: ReaderT SqlBackend (RIO env) a -> RIO env a
          (bound at src/Pantry/Storage.hs:274:1)
    |
275 |   flip SQLite.withStorage_ action =<< view (P.pantryConfigL.to P.pcStorage)
    |        ^^^^^^^^^^^^^^^^^^^
```