### PR TITLE
Allow compilation with nightly-2020-04-04 (GHC 9.2.2)

### DIFF
--- a/.azure/azure-linux-template.yml
+++ b/.azure/azure-linux-template.yml
@@ -9,6 +9,8 @@ jobs:
         ARGS: "--stack-yaml stack-ghc-86.yaml"
       GHC 8.8:
         ARGS: "--stack-yaml stack-ghc-88.yaml"
+      GHC 9.2.2:
+        ARGS: "--stack-yaml stack-ghc-922.yaml"
       persistent 2.11:
         ARGS: "--stack-yaml stack-persistent-211.yaml"
       persistent 2.13:

--- a/.azure/azure-osx-template.yml
+++ b/.azure/azure-osx-template.yml
@@ -9,6 +9,8 @@ jobs:
         ARGS: "--stack-yaml stack-ghc-86.yaml"
       GHC 8.8:
         ARGS: "--stack-yaml stack-ghc-88.yaml"
+      GHC 9.2.2:
+        ARGS: "--stack-yaml stack-ghc-922.yaml"
     maxParallel: 3
   steps:
   - script: |

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
 - template: azure-osx-template.yml
   parameters:
     name: macOS
-    vmImage: macOS-10.14
+    vmImage: macOS-11
     os: osx
 
 - template: azure-windows-template.yml

--- a/.azure/azure-windows-template.yml
+++ b/.azure/azure-windows-template.yml
@@ -10,6 +10,8 @@ jobs:
       # Buggy :(
       #GHC 8.8:
       #  ARGS: "--stack-yaml stack.yaml"
+      GHC 9.2.2:
+        ARGS: "--stack-yaml stack-ghc-922.yaml"
     maxParallel: 3
   steps:
   - bash: |

--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ dependencies:
 - persistent
 - persistent-sqlite >= 2.9.3
 - persistent-template
-- Cabal >= 3 && < 3.5
+- Cabal >= 3 && < 3.7
 - path-io
 - rio-orphans
 - conduit-extra

--- a/pantry.cabal
+++ b/pantry.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 
@@ -53,7 +53,7 @@ library
       src/
   ghc-options: -Wall
   build-depends:
-      Cabal >=3 && <3.5
+      Cabal >=3 && <3.7
     , aeson
     , ansi-terminal
     , base >=4.10 && <5
@@ -131,7 +131,7 @@ test-suite spec
       test
   ghc-options: -Wall
   build-depends:
-      Cabal >=3 && <3.5
+      Cabal >=3 && <3.7
     , QuickCheck
     , aeson
     , ansi-terminal

--- a/stack-ghc-922.yaml
+++ b/stack-ghc-922.yaml
@@ -1,0 +1,5 @@
+# GHC 9.2.2
+resolver: nightly-2022-04-04
+
+ghc-options:
+   "$locals": -fhide-source-paths


### PR DESCRIPTION
If the upper bound on the `Cabal` dependency is relaxed to allow `Cabal-3.6.3.0`, then `pantry-0.5.4` can compile with GHC 9.2.2.

Tested by compiling `pantry` using `stack --stack-yaml=stack-ghc-922.yaml build` on Windows 11. The built `pantry` then tested by using it to build `stack` with GHC 9.2.2 on Windows 11. The built `stack` then tested by using it.