### PR TITLE
Clear (third) compiler warning

### DIFF
--- a/src/Pantry/Hackage.hs
+++ b/src/Pantry/Hackage.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -42,7 +43,11 @@ import qualified Distribution.Text
 import qualified Distribution.PackageDescription as Cabal
 import qualified Data.List.NonEmpty as NE
 import Data.Text.Metrics (damerauLevenshtein)
-import System.IO (SeekMode (..)) -- Needed on GHC 8.6
+#if !MIN_VERSION_rio(0,1,16)
+-- Now provided by RIO from the rio package. Resolvers before lts-15.16
+-- (GHC 8.8.3) had rio < 0.1.16.
+import System.IO (SeekMode (..))
+#endif
 import Distribution.PackageDescription (GenericPackageDescription)
 import Distribution.Types.Version (versionNumbers)
 import Distribution.Types.VersionRange (withinRange)


### PR DESCRIPTION
Clears:

~~~
src\Pantry\Hackage.hs:45:1: warning: [-Wunused-imports]
    The import of ‘System.IO’ is redundant
      except perhaps to import instances from ‘System.IO’
    To import instances alone, use: import System.IO()
   |
45 | import System.IO (SeekMode (..)) -- Needed on GHC 8.6
~~~

The need for the import from `System.IO` is not GHC 8.6 but `rio < 0.1.16.0`.