### PR TITLE
Add space in Cabal file warning

### DIFF
--- a/src/Pantry.hs
+++ b/src/Pantry.hs
@@ -666,7 +666,7 @@ loadCabalFilePath dir = do
 
     toPretty :: Path Abs File -> PWarning -> Utf8Builder
     toPretty src (PWarning _type pos msg) =
-      "Cabal file warning in" <>
+      "Cabal file warning in " <>
       fromString (toFilePath src) <> "@" <>
       fromString (showPos pos) <> ": " <>
       fromString msg


### PR DESCRIPTION
Before:
```
Cabal file warning in/path/to/foo.cabal
```
After:
```
Cabal file warning in /path/to/foo.cabal
```