### PR TITLE
Separate true `HackageSecurityConfig` from (renamed) `PackageIndexConfig`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,19 @@
 # Changelog for pantry
 
+## v0.6.0
+
+* Rename `HackageSecurityConfig` as `PackageIndexConfig`,
+  `defaultHackageSecurityConfig` as `defaultPackageIndexConfig`, and
+  `pcHackageSecurity` field of `PantryConfig` as `pcPackageIndex`.
+* Expose new `HackageSecurityConfig` and `defaultHackageSecurityConfig`. The
+  former represents Hackage Security configurations (only - no download prefix).
+* Change the data constructor of `PackageIndexConfig` to have fields for a
+  download prefix (type `Text`) and of type `HackageSecurityConfig`.
+* The `WithJSONWarnings PackageIndexConfig` instance of `FromJSON` now assigns
+  default value `defaultHackageSecurityConfig` if the `hackage-security` key is
+  absent from the JSON object.
+* Expose `defaultDownloadPrefix`, for the official Hackage server.
+
 ## v0.5.7
 
 * Expose `loadAndCompleteSnapshotRaw'` and `loadAndCompleteSnapshot'`, which

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        pantry
-version:     0.5.7
+version:     0.6.0
 synopsis:    Content addressable Haskell package management
 description: Please see the README on GitHub at <https://github.com/commercialhaskell/pantry#readme>
 category:    Development

--- a/pantry.cabal
+++ b/pantry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           pantry
-version:        0.5.7
+version:        0.6.0
 synopsis:       Content addressable Haskell package management
 description:    Please see the README on GitHub at <https://github.com/commercialhaskell/pantry#readme>
 category:       Development

--- a/src/Pantry/Hackage.hs
+++ b/src/Pantry/Hackage.hs
@@ -125,7 +125,7 @@ updateHackageIndexInternal forceUpdate mreason = do
   gateUpdate $ withWriteLock_ storage $ do
     for_ mreason logInfo
     pc <- view pantryConfigL
-    let HackageSecurityConfig keyIds threshold url ignoreExpiry = pcHackageSecurity pc
+    let PackageIndexConfig url (HackageSecurityConfig keyIds threshold ignoreExpiry) = pcPackageIndex pc
     root <- view hackageDirL
     tarball <- view hackageIndexTarballL
     baseURI <-
@@ -606,7 +606,7 @@ getHackageTarball pir mtreeKey = do
             Nothing -> throwIO exc
             Just pair2 -> pure pair2
     pc <- view pantryConfigL
-    let urlPrefix = hscDownloadPrefix $ pcHackageSecurity pc
+    let urlPrefix = picDownloadPrefix $ pcPackageIndex pc
         url =
           mconcat
             [ urlPrefix


### PR DESCRIPTION
This pull request proposes a relatively minor, but breaking, change to Pantry's API. There is a corresponding pull request for Stack that adopts this version of the Pantry API. There is one other package on Hackage with a dependency on Pantry - `mega-sdist`. If this pull request is accepted I will propose a pull request for that package to update it for `pantry-0.6.0`.

(EDIT: [`commercialhaskell/curator](https://github.com/commercialhaskell/curator) also depend on Pantry, but the current version of Curator compiles with this changed version of Pantry.)

The motivation for this proposal is the request at Stack issue [#5870](https://github.com/commercialhaskell/stack/issues/5870).

What is currently referred to as `HackageSecurityConfig` is better named `PackageIndexConfig`, comprising a true `HackageSecuityConfig` value and a download prefix (`picDownloadPrefix :: !Text`).

What is currently referred to as `defaultHackageSecurityConfig` is renamed `defaultPackageIndexConfig`.

True `HackageSecurityConfig` (strictly, `WithJSONWarnings HackageSecurityConfig`) has its own instance of `FromJSON` and its own default: `defaultHackageSecurityConfig`.

Meeting the ask in the Stack issue, the instance of `FromJSON` for `PackageIndexConfig` now assigns a default value of `defaultHackageSecurityConfig` if the `hackage-security` key is absent from the JSON object. I am proposing that this change should be in the Pantry library. If that is not accepted, the change could be made in Stack by making use of a `newtype` there.

The field of `PackageConfig` named `pcHackageSecuity :: !HackageSecurityConfig` is renamed `pcPackageIndex :: !PackageIndexConfig`.

For completeness, `defaultDownloadPrefix` is also exposed.