### PR TITLE
Fix #62 Change `defaultHackageSecurityConfig` to be consistent

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for pantry
 
+## v0.7.0
+
+* Change `defaultHackageSecurityConfig` such that field
+  `hscIgnoreExpiry = True`, to be consistent with the defaults of the
+  `WithJSONWarnings HackageSecurityConfig` instance of `FromJSON`.
+
 ## v0.6.0
 
 * Rename `HackageSecurityConfig` as `PackageIndexConfig`,

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        pantry
-version:     0.6.0
+version:     0.7.0
 synopsis:    Content addressable Haskell package management
 description: Please see the README on GitHub at <https://github.com/commercialhaskell/pantry#readme>
 category:    Development

--- a/pantry.cabal
+++ b/pantry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           pantry
-version:        0.6.0
+version:        0.7.0
 synopsis:       Content addressable Haskell package management
 description:    Please see the README on GitHub at <https://github.com/commercialhaskell/pantry#readme>
 category:       Development

--- a/src/Pantry/Types.hs
+++ b/src/Pantry/Types.hs
@@ -636,8 +636,9 @@ instance FromJSON (WithJSONWarnings PackageIndexConfig) where
     pure PackageIndexConfig {..}
 
 -- | Default 'HackageSecurityConfig' value using the official Hackage server.
+-- The value of the 'hscIgnoreExpiry' field is 'True'.
 --
--- @since 0.6.0
+-- @since 0.7.0
 defaultHackageSecurityConfig :: HackageSecurityConfig
 defaultHackageSecurityConfig = HackageSecurityConfig
   { hscKeyIds =
@@ -648,7 +649,7 @@ defaultHackageSecurityConfig = HackageSecurityConfig
       , "fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0"
       ]
   , hscKeyThreshold = 3
-  , hscIgnoreExpiry = False
+  , hscIgnoreExpiry = True
   }
 
 -- | Configuration for Hackage Security to securely download package metadata
@@ -667,6 +668,10 @@ data HackageSecurityConfig = HackageSecurityConfig
   }
   deriving Show
 
+-- | If the @ignore-expiry@ key is absent from the JSON object, assigns default
+-- value 'True'.
+--
+-- @since 0.1.1.0
 instance FromJSON (WithJSONWarnings HackageSecurityConfig) where
   parseJSON = withObjectWarnings "HackageSecurityConfig" $ \o -> do
     hscKeyIds <- o ..: "keyids"


### PR DESCRIPTION
Also bumps `pantry-0.6.0` to 0.7.0 due to changed behaviour of an exported function.

Flags the default value of `hscIgnoreExpiry` in the Haddock documentation.