### PR TITLE
Fix #69 Don't hard code "stack" as Hpack program name

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Changelog for pantry
 
+## v0.8.0
+
+* `findOrGenerateCabalFile`, `loadCabalFilePath`, `loadCabalFile` and
+  `loadCabalFileRaw` no longer assume that the program name used by Hpack (the
+  library) is "stack", and take a new initial argument of type `Maybe Text` to
+  specify the desired program name. The default is "hpack".
+
 ## v0.7.1
 
 * To support the Haskell Foundation's

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        pantry
-version:     0.7.1
+version:     0.8.0
 synopsis:    Content addressable Haskell package management
 description: Please see the README on GitHub at <https://github.com/commercialhaskell/pantry#readme>
 category:    Development

--- a/pantry.cabal
+++ b/pantry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           pantry
-version:        0.7.1
+version:        0.8.0
 synopsis:       Content addressable Haskell package management
 description:    Please see the README on GitHub at <https://github.com/commercialhaskell/pantry#readme>
 category:       Development

--- a/src/Pantry/Archive.hs
+++ b/src/Pantry/Archive.hs
@@ -14,7 +14,7 @@ module Pantry.Archive
 
 import RIO
 import qualified Pantry.SHA256 as SHA256
-import Pantry.Storage hiding (Tree, TreeEntry)
+import Pantry.Storage hiding (Tree, TreeEntry, findOrGenerateCabalFile)
 import Pantry.Tree
 import Pantry.Types
 import RIO.Process

--- a/src/Pantry/Casa.hs
+++ b/src/Pantry/Casa.hs
@@ -10,7 +10,7 @@ import qualified Casa.Types as Casa
 import           Conduit
 import qualified Data.HashMap.Strict as HM
 import qualified Pantry.SHA256 as SHA256
-import           Pantry.Storage
+import           Pantry.Storage hiding (findOrGenerateCabalFile)
 import           Pantry.Types as P
 import           RIO
 import qualified RIO.ByteString as B

--- a/src/Pantry/Hackage.hs
+++ b/src/Pantry/Hackage.hs
@@ -33,7 +33,8 @@ import qualified RIO.ByteString as B
 import qualified RIO.ByteString.Lazy as BL
 import Pantry.Archive
 import Pantry.Types hiding (FileType (..))
-import Pantry.Storage hiding (TreeEntry, PackageName, Version)
+import Pantry.Storage
+         hiding (TreeEntry, PackageName, Version, findOrGenerateCabalFile)
 import Pantry.Tree
 import qualified Pantry.SHA256 as SHA256
 import Network.URI (parseURI)

--- a/src/Pantry/Repo.hs
+++ b/src/Pantry/Repo.hs
@@ -17,7 +17,7 @@ module Pantry.Repo
 
 import Pantry.Types
 import Pantry.Archive
-import Pantry.Storage
+import Pantry.Storage hiding (findOrGenerateCabalFile)
 import RIO
 import Path.IO (resolveFile')
 import RIO.FilePath ((</>))

--- a/src/Pantry/Tree.hs
+++ b/src/Pantry/Tree.hs
@@ -10,7 +10,7 @@ import RIO
 import qualified RIO.Map as Map
 import qualified RIO.Text as T
 import qualified RIO.ByteString as B
-import Pantry.Storage hiding (Tree, TreeEntry)
+import Pantry.Storage hiding (Tree, TreeEntry, findOrGenerateCabalFile)
 import Pantry.Types
 import RIO.FilePath ((</>), takeDirectory)
 import RIO.Directory (createDirectoryIfMissing, setPermissions, getPermissions, setOwnerExecutable)

--- a/test/Pantry/FileSpec.hs
+++ b/test/Pantry/FileSpec.hs
@@ -10,7 +10,7 @@ spec :: Spec
 spec = describe "loadCabalFilePath" $ do
   it "sanity" $ do
     abs' <- resolveDir' "."
-    (f, name, cabalfp) <- runPantryApp $ loadCabalFilePath abs'
+    (f, name, cabalfp) <- runPantryApp $ loadCabalFilePath Nothing abs'
     suffix <- parseRelFile "pantry.cabal"
     cabalfp `shouldBe` abs' </> suffix
     name' <- parsePackageNameThrowing "pantry"


### PR DESCRIPTION
Like Stack, also refers to Hpack as 'Hpack' (unless referring to the command 'hpack') and refers to Cabal files as 'Cabal files' rather than '.cabal' files (unless the context is the extension to the files).

If this pull request is accepted, I will update Stack accordingly.

(As an aside, I also have a suggestion in another area that could be included in a `pantry-0.8.0`.)