### PR TITLE
Fix #71 Handle exceptions thrown by Hpack

### DIFF
--- a/src/Pantry/Types.hs
+++ b/src/Pantry/Types.hs
@@ -970,6 +970,8 @@ data PantryException
   | MigrationFailure !Text !(Path Abs File) !SomeException
   | InvalidTreeFromCasa !BlobKey !ByteString
   | ParseSnapNameException !Text
+  | HpackLibraryException !(Path Abs File) !SomeException
+  | HpackExeException !FilePath !(Path Abs Dir) !SomeException
 
   deriving Typeable
 instance Exception PantryException where
@@ -1276,6 +1278,22 @@ instance Display PantryException where
     "Error: [S-994]\n"
      <> "Invalid snapshot name: "
      <> display t
+  display (HpackLibraryException file e) =
+    "Error: [S-305]\n"
+    <> "Failed to generate a Cabal file using the Hpack library on file:\n"
+    <> fromString (toFilePath file)
+    <> "\n\n"
+    <> "The exception encountered was:\n\n"
+    <> fromString (show e)
+  display (HpackExeException fp dir e) =
+    "Error: [S-720]\n"
+    <> "Failed to generate a Cabal file using the Hpack executable:\n"
+    <> fromString fp
+    <> "in directory: "
+    <> fromString (toFilePath dir)
+    <> "\n\n"
+    <> "The exception encountered was:\n\n"
+    <> fromString (show e)
 
 data FuzzyResults
   = FRNameNotFound ![PackageName]


### PR DESCRIPTION
Pantry explains that exception types may be thrown from underlying libraries and that it does not attempt to wrap them. See https://hackage.haskell.org/package/pantry-0.7.1/docs/Pantry.html#g:4. However, I suggest that an exception be made for exceptions encountered while using Hpack, because package.yaml is fundamental to the user experience.

For example, rather than a user being presented by Stack with just:

~~~text
D:\Users\mike\Code\Haskell\foo\package.yaml:61:0: could not find expected ':' while scanning a simple key 
~~~

the user would be presented with:

~~~text
D:\Users\mike\Code\Haskell\foo\package.yaml:61:0: could not find expected ':' while scanning a simple key Error: [S-305]
Failed to generate a Cabal file using the Hpack library on file: D:\Users\mike\Code\Haskell\foo\package.yaml

The exception encountered was:

ExitFailure 1
~~~