### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/pantry.cabal linguist-generated=true
+/*.yaml.lock linguist-generated=true


### PR DESCRIPTION
This will initially hide generated files wehen looking at a PR on GitHub:

![DE55EBB9-1D81-444C-AA00-B6590789CE50](https://user-images.githubusercontent.com/461132/206890872-ae4690b2-7192-480f-a033-1396c4046333.jpeg)

This is just a suggestion, but I think it helps focusing on the relevant things when looking at PRs.