### PR TITLE
ci: Don't test all os / resolver combinations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,6 @@ jobs:
         # built on Fedora 33, whuch comes with glibc version 2.32. Hence use
         # ubuntu-22.04.
         - ubuntu-22.04
-        - macos-latest
-        - windows-latest
         stack-yaml:
         - stack-ghc-8.6.5.yaml
         - stack-ghc-8.8.4.yaml
@@ -32,6 +30,11 @@ jobs:
         - stack-ghc-9.4.2.yaml
         - stack-persistent-2.11.yaml
         - stack-cabal-3.4.yaml
+        include:
+        - os: macos-latest
+          stack-yaml: stack.yaml
+        - os: windows-latest
+          stack-yaml: stack.yaml
     steps:
     - name: Clone project
       uses: actions/checkout@v3


### PR DESCRIPTION
As things are we don't fully benefit from dependency caching, resulting in excessive build  times.

The reason for this is that the total space requirement for all the caches of our build matrix exceeds the GithHub quota of 10 GB. This results in  caches being evicted before they can ever be reused.

I usually address this by testing only the latest version of GHC on Windows / OSX, while running tests for older versions on Linux only.

**I acknowledge that it's not a perfect solution. It's a trade-off between speedy builds and coverage. You guys have to make a call whether this is the right thing to do for `pantry`.**

Impact: This PR should bring down the build time from 45m to less than 5m.