### PR TITLE
Extend Hpack.AlreadyGeneratedByNewerHpack warning

### DIFF
--- a/src/Pantry.hs
+++ b/src/Pantry.hs
@@ -785,13 +785,19 @@ hpack progName pkgDir = do
                       logDebug $ "Hpack output unchanged in " <> cabalFile
                     Hpack.AlreadyGeneratedByNewerHpack -> logWarn $
                         cabalFile <>
-                        " was generated with a newer version of Hpack,\n" <>
-                        "please upgrade and try again."
+                        " was generated with a newer version of Hpack. Ignoring " <>
+                        fromString (toFilePath hpackFile) <>
+                        " in favor of the Cabal file.\n" <>
+                        "Either please upgrade and try again or, if you want to use the " <>
+                        fromString (toFilePath (filename hpackFile)) <>
+                        " file instead of the Cabal file,\n" <>
+                        "then please delete the Cabal file."
                     Hpack.ExistingCabalFileWasModifiedManually -> logWarn $
                         cabalFile <>
                         " was modified manually. Ignoring " <>
                         fromString (toFilePath hpackFile) <>
-                        " in favor of the Cabal file.\nIf you want to use the " <>
+                        " in favor of the Cabal file.\n" <>
+                        "If you want to use the " <>
                         fromString (toFilePath (filename hpackFile)) <>
                         " file instead of the Cabal file,\n" <>
                         "then please delete the Cabal file."

--- a/src/Pantry/HPack.hs
+++ b/src/Pantry/HPack.hs
@@ -57,16 +57,22 @@ hpack pkgDir = do
                     Hpack.OutputUnchanged -> logDebug $ "hpack output unchanged in " <> cabalFile
                     Hpack.AlreadyGeneratedByNewerHpack -> logWarn $
                         cabalFile <>
-                        " was generated with a newer version of hpack,\n" <>
-                        "please upgrade and try again."
+                        " was generated with a newer version of hpack. Ignoring " <>
+                        fromString (toFilePath hpackFile) <>
+                        " in favor of the Cabal file.\n" <>
+                        "Either please upgrade and try again or, if you want to use the " <>
+                        fromString (toFilePath (filename hpackFile)) <>
+                        " file instead of the Cabal file,\n" <>
+                        "then please delete the Cabal file."
                     Hpack.ExistingCabalFileWasModifiedManually -> logWarn $
                         cabalFile <>
                         " was modified manually. Ignoring " <>
                         fromString (toFilePath hpackFile) <>
-                        " in favor of the cabal file.\nIf you want to use the " <>
+                        " in favor of the Cabal file.\n" <>
+                        "If you want to use the " <>
                         fromString (toFilePath (filename hpackFile)) <>
-                        " file instead of the cabal file,\n" <>
-                        "then please delete the cabal file."
+                        " file instead of the Cabal file,\n" <>
+                        "then please delete the Cabal file."
             HpackCommand command ->
                 withWorkingDir (toFilePath pkgDir) $
                 proc command [] runProcess_


### PR DESCRIPTION
Fixes https://github.com/commercialhaskell/stack/issues/6057.

Hpack does not over-write an existing Cabal file, if it was generated by a more recent version of Hpack. Pantry, when it is using its built-in version of Hpack, warns when this occurs but does not consider it fatal - it will go on to use the existing Cabal file that was not over-written.

This extends the warning for `Hpack.AlreadyGeneratedByNewerHpack` to include the existing advice given for `Hpack.ExistingCabalFileWasModifiedManually`, which is equally applicable.