### PR TITLE
Add an executable to test form of pretty exceptions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,3 +52,36 @@ jobs:
       run: |
         set -ex
         stack test --stack-yaml ${{ matrix.stack-yaml }} --bench --no-run-benchmarks --haddock --no-haddock-deps
+  test-pretty-exceptions:
+    name: Test build of test-pretty-exceptions
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-latest
+        - windows-latest
+        stack-yaml:
+        - stack.yaml # GHC 9.2.7
+    steps:
+    - name: Clone project
+      uses: actions/checkout@v3
+    - name: Cache dependencies on Unix-like OS
+      if: startsWith(runner.os, 'Linux') || startsWith(runner.os, 'macOS')
+      uses: actions/cache@v3
+      with:
+        path: ~/.stack
+        key: ${{ runner.os }}-${{ matrix.stack-yaml }}-pretty
+    - name: Cache dependencies on Windows
+      if: startsWith(runner.os, 'Windows')
+      uses: actions/cache@v3
+      with:
+        path: |
+           ~\AppData\Roaming\stack
+           ~\AppData\Local\Programs\stack
+        key: ${{ runner.os }}-${{ matrix.stack-yaml }}-pretty
+    - name: Build test-pretty-exceptions
+      shell: bash
+      run: |
+        set -ex
+        stack --stack-yaml ${{ matrix.stack-yaml }} build --flag pantry:test-pretty-exceptions

--- a/app/test-pretty-exceptions/Main.hs
+++ b/app/test-pretty-exceptions/Main.hs
@@ -1,0 +1,415 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TupleSections     #-}
+
+-- | An executable to allow a person to inspect in a terminal the form of
+-- Pantry's pretty exceptions.
+module Main
+ ( main
+ ) where
+
+import qualified Data.Conduit.Tar as Tar
+import           Data.Maybe ( fromJust )
+import qualified Data.Text as T
+import qualified Distribution.Parsec.Error as C
+import qualified Distribution.Parsec.Position as C
+import qualified Distribution.Parsec.Warning as C
+import qualified Distribution.Types.PackageName as C
+import qualified Distribution.Types.Version as C
+import           Options.Applicative
+                   ( Parser, (<**>), auto, execParser, fullDesc, header, help
+                   , helper, info, long, metavar, option, progDesc, showDefault
+                   , strOption, value
+                   )
+import           Network.HTTP.Types.Status ( Status, mkStatus )
+import           Pantry
+                   ( ArchiveLocation (..), BlobKey (..), CabalFileInfo (..)
+                   , FileSize (..), FuzzyResults (..), Mismatch (..)
+                   , PackageName, PantryException (..), PackageIdentifier (..)
+                   , PackageIdentifierRevision (..), PackageMetadata (..)
+                   , RawPackageLocationImmutable (..), RawPackageMetadata (..)
+                   , RawSnapshotLocation (..), RelFilePath (..), Repo (..)
+                   , RepoType (..), ResolvedPath (..), Revision (..), SHA256
+                   , SafeFilePath, SimpleRepo (..), SnapName (..)
+                   , TreeKey (..), Version, WantedCompiler (..), mkSafeFilePath
+                   )
+import           Pantry.SHA256 ( hashBytes )
+import           Path ( File )
+import           PathAbsExamples
+                   ( pathAbsDirExample, pathAbsFileExample
+                   , pathAbsFileExamples
+                   )
+import           RIO
+import qualified RIO.List as L
+import           RIO.NonEmpty ( nonEmpty )
+import           RIO.PrettyPrint ( pretty, prettyError )
+import           RIO.PrettyPrint.Simple ( SimplePrettyApp, runSimplePrettyApp )
+import           RIO.PrettyPrint.StylesUpdate
+                   ( StylesUpdate, parseStylesUpdateFromString )
+import           RIO.Time ( fromGregorian )
+import           System.Terminal ( hIsTerminalDeviceOrMinTTY, getTerminalWidth )
+
+-- | Type representing options that can be specified at the command line
+data Options = Options
+  { colours :: String
+  , theme :: Theme
+  }
+
+-- | Type representing styles identified by a theme name
+data Theme
+  = Default
+  | SolarizedDark
+  deriving (Bounded, Enum, Read, Show)
+
+options :: Parser Options
+options = Options
+  <$> strOption
+        (  long "colours"
+        <> metavar "STYLES"
+        <> help "Specify the output styles; STYLES is a colon-delimited \
+                \sequence of key=value, where 'key' is a style name and \
+                \'value' is a semicolon-delimited list of 'ANSI' SGR (Select \
+                \Graphic Rendition) control codes (in decimal). In shells \
+                \where a semicolon is a command separator, enclose STYLES in \
+                \quotes."
+        <> value ""
+        )
+  <*> option auto
+        ( long "theme"
+        <> metavar "THEME"
+        <> help (  "Specify a theme for output styles. THEME is one of: "
+                <> showThemes <> "."
+                )
+        <> value Default
+        <> showDefault
+        )
+ where
+  showThemes = L.intercalate " " $ map show ([minBound .. maxBound] :: [Theme])
+
+fromTheme :: Theme -> StylesUpdate
+fromTheme Default = mempty
+fromTheme SolarizedDark = parseStylesUpdateFromString
+  "error=31:good=32:shell=35:dir=34:recommendation=32:target=95:module=35:package-component=95:secondary=92:highlight=32"
+
+main :: IO ()
+main = do
+  isTerminal <- hIsTerminalDeviceOrMinTTY stderr
+  if isTerminal
+    then do
+      terminalWidth <- fromMaybe 80 <$> getTerminalWidth
+      mainInTerminal terminalWidth =<< execParser opts
+    else
+      putStrLn "This executable is intended to be run with the standard error \
+               \ channel connected to a terminal. No terminal detected."
+ where
+  opts = info (options <**> helper)
+    (  fullDesc
+    <> progDesc "Allows a person to inspect in a terminal the form of Pantry's \
+                \pretty exceptions."
+    <> header "test-pretty-exceptions - test Pantry's pretty exceptions"
+    )
+
+mainInTerminal :: Int -> Options -> IO ()
+mainInTerminal terminalWidth Options{..} = do
+  let stylesUpdate = fromTheme theme <> parseStylesUpdateFromString colours
+  runSimplePrettyApp terminalWidth stylesUpdate action
+ where
+  action :: RIO SimplePrettyApp ()
+  action = mapM_ (prettyError . pretty) examples
+
+-- | The intention is that there shoud be examples for every data constructor of
+-- the PantryException type.
+examples :: [PantryException]
+examples = concat
+  [ [ PackageIdentifierRevisionParseFail hackageMsg ]
+  , [ InvalidCabalFile loc version pErrorExamples pWarningExamples
+    | loc <- map Left rawPackageLocationImmutableExamples <> [Right pathAbsFileExample]
+    , version <- [Nothing, Just versionExample]
+    ]
+  , [ TreeWithoutCabalFile rawPackageLocationImmutable
+    | rawPackageLocationImmutable <- rawPackageLocationImmutableExamples
+    ]
+  , [ TreeWithMultipleCabalFiles rawPackageLocationImmutable safeFilePathExamples
+    | rawPackageLocationImmutable <- rawPackageLocationImmutableExamples
+    ]
+  , [ MismatchedCabalName pathAbsFileExample packageNameExample ]
+  , [ NoCabalFileFound pathAbsDirExample ]
+  , [ MultipleCabalFilesFound pathAbsDirExample pathAbsFileExamples ]
+  , [ InvalidWantedCompiler "my-wanted-compiler" ]
+  , [ InvalidSnapshotLocation pathAbsDirExample rawPathExample ]
+  , [ InvalidOverrideCompiler wantedCompiler1 wantedCompiler2
+    | wantedCompiler1 <- wantedCompilerExamples
+    , wantedCompiler2 <- wantedCompilerExamples
+    ]
+  , [ InvalidFilePathSnapshot rawPathExample ]
+  , [ InvalidSnapshot rawSnapshotLocation someExceptionExample
+    | rawSnapshotLocation <- rawSnapshotLocationExamples
+    ]
+  , [ MismatchedPackageMetadata rawPackageLocationImmutable rawPackageMetadata treeKey packageIdentifierExample
+    | rawPackageLocationImmutable <- rawPackageLocationImmutableExamples
+    , rawPackageMetadata <- rawPackageMetadataExamples
+    , treeKey <- [Nothing, Just treeKeyExample]
+    ]
+  , [ Non200ResponseStatus statusExample ]
+  , [ InvalidBlobKey (Mismatch blobKeyExample blobKeyExample) ]
+  , [ Couldn'tParseSnapshot rawSnapshotLocation errorMessageExample
+    | rawSnapshotLocation <- rawSnapshotLocationExamples
+    ]
+  , [ WrongCabalFileName rawPackageLocationImmutable safeFilePathExample packageNameExample
+    | rawPackageLocationImmutable <- rawPackageLocationImmutableExamples
+    ]
+  , [ DownloadInvalidSHA256 urlExample (Mismatch sha256Example sha256Example) ]
+  , [ DownloadInvalidSize urlExample (Mismatch fileSizeExample fileSizeExample) ]
+  , [ DownloadTooLarge urlExample (Mismatch fileSizeExample fileSizeExample) ]
+  , [ LocalInvalidSHA256 pathAbsFileExample (Mismatch sha256Example sha256Example) ]
+  , [ LocalInvalidSize pathAbsFileExample (Mismatch fileSizeExample fileSizeExample) ]
+  , [ UnknownArchiveType archiveLocation
+    | archiveLocation <- archiveLocationExamples
+    ]
+  , [ InvalidTarFileType archiveLocation filePathExample fileTypeExample
+    | archiveLocation <- archiveLocationExamples
+    ]
+  , [ UnsupportedTarball archiveLocation (T.pack errorMessageExample)
+    | archiveLocation <- archiveLocationExamples
+    ]
+  , [ NoHackageCryptographicHash packageIdentifierExample ]
+  , [ FailedToCloneRepo simpleRepoExample ]
+  , [ TreeReferencesMissingBlob rawPackageLocationImmutable safeFilePathExample blobKeyExample
+    | rawPackageLocationImmutable <- rawPackageLocationImmutableExamples
+    ]
+  , [ CompletePackageMetadataMismatch rawPackageLocationImmutable packageMetadataExample
+    | rawPackageLocationImmutable <- rawPackageLocationImmutableExamples
+    ]
+  , [ CRC32Mismatch archiveLocation filePathExample (Mismatch 1024 1024 )
+    | archiveLocation <- archiveLocationExamples
+    ]
+  , [ UnknownHackagePackage packageIdentifierRevisionExample fuzzyResults
+    | packageIdentifierRevisionExample <- packageIdentifierRevisionExamples
+    , fuzzyResults <- fuzzyResultsExamples
+    ]
+  , [ CannotCompleteRepoNonSHA1 repoExample ]
+  , [ MutablePackageLocationFromUrl urlExample ]
+  , [ MismatchedCabalFileForHackage packageIdentifierRevision (Mismatch packageIdentifierExample packageIdentifierExample)
+    | packageIdentifierRevision <- packageIdentifierRevisionExamples
+    ]
+  , [ PackageNameParseFail rawPackageName ]
+  , [ PackageVersionParseFail rawPackageVersion ]
+  , [ InvalidCabalFilePath pathAbsFileExample ]
+  , [ DuplicatePackageNames sourceMsgExample duplicatePackageNamesExamples ]
+  , [ MigrationFailure descriptionExample pathAbsFileExample someExceptionExample ]
+  , [ InvalidTreeFromCasa blobKeyExample blobExample ]
+  , [ ParseSnapNameException rawSnapNameExample ]
+  , [ HpackLibraryException pathAbsFileExample errorMessageExample ]
+  , [ HpackExeException hpackCommandExample pathAbsDirExample someExceptionExample ]
+  ]
+
+hackageMsg :: Text
+hackageMsg = "<Example message from Hackage.>"
+
+pErrorExamples :: [C.PError]
+pErrorExamples =
+  [ C.PError (C.Position 10 20) "<Example error message1.>"
+  , C.PError (C.Position 12 10) "<Example error message2.>"
+  , C.PError (C.Position 14 30) "<Example error message3.>"
+  ]
+
+pWarningExamples :: [C.PWarning]
+pWarningExamples =
+  [ C.PWarning C.PWTOther (C.Position 10 20) "<Example warning message1.>"
+  , C.PWarning C.PWTOther (C.Position 12 10) "<Example warning message2.>"
+  , C.PWarning C.PWTOther (C.Position 14 30) "<Example warning message3.>"
+  ]
+
+packageNameExample :: PackageName
+packageNameExample = C.mkPackageName "my-package"
+
+versionExample :: Version
+versionExample = C.mkVersion [1, 0, 0]
+
+sha256Example :: SHA256
+sha256Example = hashBytes "example"
+
+fileSizeExample :: FileSize
+fileSizeExample = FileSize 1234
+
+revisionExample :: Revision
+revisionExample = Revision 1
+
+cabalFileInfoExamples :: [CabalFileInfo]
+cabalFileInfoExamples = concat
+  [ [CFILatest]
+  , [ CFIHash sha256Example fileSize
+    | fileSize <- [Nothing, Just fileSizeExample]
+    ]
+  , [CFIRevision revisionExample]
+  ]
+
+packageIdentifierRevisionExamples :: [PackageIdentifierRevision]
+packageIdentifierRevisionExamples =
+  [ PackageIdentifierRevision packageNameExample versionExample cabalFileInfo
+  | cabalFileInfo <- cabalFileInfoExamples
+  ]
+
+blobKeyExample :: BlobKey
+blobKeyExample = BlobKey sha256Example fileSizeExample
+
+treeKeyExample :: TreeKey
+treeKeyExample = TreeKey blobKeyExample
+
+rawPackageLocationImmutableExamples :: [RawPackageLocationImmutable]
+rawPackageLocationImmutableExamples = concat
+  [ [ RPLIHackage packageIdentifierRevision treeKey
+    | packageIdentifierRevision <- packageIdentifierRevisionExamples
+    , treeKey <- [Nothing, Just treeKeyExample]
+    ]
+--, RPLIArchive
+  , [ RPLIRepo repoExample rawPackageMetadata
+    | rawPackageMetadata <- rawPackageMetadataExamples
+    ]
+  ]
+
+safeFilePathExamples :: [SafeFilePath]
+safeFilePathExamples =
+  [ fromJust $ mkSafeFilePath "Users/jane/my-project-dir/example1.ext"
+  , fromJust $ mkSafeFilePath "Users/jane/my-project-dir/example2.ext"
+  , fromJust $ mkSafeFilePath "Users/jane/my-project-dir/example3.ext"
+  ]
+
+rawPathExample :: Text
+rawPathExample = "<Example raw path.>"
+
+wantedCompilerExamples :: [WantedCompiler]
+wantedCompilerExamples =
+  [ WCGhc versionExample
+  , WCGhcGit "<commit1>" "<commit2>"
+  , WCGhcjs versionExample versionExample
+  ]
+
+data ExceptionExample
+  = ExceptionExample !Text
+  deriving (Show, Typeable)
+
+instance Exception ExceptionExample where
+  displayException (ExceptionExample t) = T.unpack t
+
+errorMessageExample :: String
+errorMessageExample =
+  "This is the first line of some example text for the message in an exception \
+  \example. This is example text for an exception example.\n\
+  \This is the second line of some example text for the message in an exception \
+  \example. This is example text for an exception example."
+
+someExceptionExample :: SomeException
+someExceptionExample =
+  SomeException (ExceptionExample $ T.pack errorMessageExample)
+
+urlExample :: Text
+urlExample = "https://example.com"
+
+relFilePathExample :: RelFilePath
+relFilePathExample = RelFilePath "jane/my-project-dir"
+
+resolvedPathFileExample :: ResolvedPath File
+resolvedPathFileExample = ResolvedPath relFilePathExample pathAbsFileExample
+
+snapNameExamples :: [SnapName]
+snapNameExamples =
+  [ LTS 20 17
+  , Nightly $ fromGregorian 2023 4 5
+  ]
+
+rawSnapshotLocationExamples :: [RawSnapshotLocation]
+rawSnapshotLocationExamples = concat
+  [ [ RSLCompiler wantedCompiler
+    | wantedCompiler <- wantedCompilerExamples
+    ]
+  , [ RSLUrl urlExample blobKey
+    | blobKey <- [Nothing, Just blobKeyExample]
+    ]
+  , [ RSLFilePath resolvedPathFileExample ]
+  , [ RSLSynonym snapNameExample
+    | snapNameExample <- snapNameExamples
+    ]
+  ]
+
+rawPackageMetadataExamples :: [RawPackageMetadata]
+rawPackageMetadataExamples =
+  [ RawPackageMetadata name version treeKey
+  | name <- [ Nothing, Just packageNameExample]
+  , version <- [ Nothing, Just versionExample ]
+  , treeKey <- [Nothing, Just treeKeyExample]
+  ]
+
+statusExample :: Status
+statusExample = mkStatus 100 "<Example status message.>"
+
+safeFilePathExample :: SafeFilePath
+safeFilePathExample =
+  fromJust $ mkSafeFilePath "Users/jane/my-project-dir/example.ext"
+
+archiveLocationExamples :: [ArchiveLocation]
+archiveLocationExamples =
+  [ ALUrl urlExample
+  , ALFilePath resolvedPathFileExample
+  ]
+
+filePathExample :: FilePath
+filePathExample = "<file-path>"
+
+fileTypeExample :: Tar.FileType
+fileTypeExample = Tar.FTNormal
+
+commitExample :: Text
+commitExample = "b8b34bf5571de75909d97f687e3d37909b1dc9f7"
+
+simpleRepoExample :: SimpleRepo
+simpleRepoExample = SimpleRepo urlExample commitExample RepoGit
+
+packageIdentifierExample :: PackageIdentifier
+packageIdentifierExample = PackageIdentifier packageNameExample versionExample
+
+packageMetadataExample :: PackageMetadata
+packageMetadataExample = PackageMetadata packageIdentifierExample treeKeyExample
+
+fuzzyResultsExamples :: [FuzzyResults]
+fuzzyResultsExamples =
+  [ FRNameNotFound packageNameExamples
+  , FRVersionNotFound $ fromJust $ nonEmpty packageIdentifierRevisionExamples
+  , FRRevisionNotFound $ fromJust $ nonEmpty packageIdentifierRevisionExamples
+  ]
+
+repoExample :: Repo
+repoExample = Repo urlExample commitExample RepoGit "my-subdirectory"
+
+rawPackageName :: Text
+rawPackageName = "<raw-package-name>"
+
+rawPackageVersion :: Text
+rawPackageVersion = "<raw-package-version>"
+
+sourceMsgExample :: Utf8Builder
+sourceMsgExample = "<Example source message.>"
+
+packageNameExamples :: [PackageName]
+packageNameExamples =
+  [ C.mkPackageName "my-package1"
+  , C.mkPackageName "my-package2"
+  , C.mkPackageName "my-package3"
+  ]
+
+duplicatePackageNamesExamples :: [(PackageName, [RawPackageLocationImmutable])]
+duplicatePackageNamesExamples = map
+  ((, rawPackageLocationImmutableExamples))
+  packageNameExamples
+
+descriptionExample :: Text
+descriptionExample = "<Example description.>"
+
+blobExample :: ByteString
+blobExample = "b8b34bf5571de75909d97f687e3d37909b1dc9f7"
+
+rawSnapNameExample :: Text
+rawSnapNameExample = "<raw-snapshot-name>"
+
+hpackCommandExample :: FilePath
+hpackCommandExample = "<path-to-hpack>/hpack"

--- a/app/test-pretty-exceptions/unix/PathAbsExamples.hs
+++ b/app/test-pretty-exceptions/unix/PathAbsExamples.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | The module of this name differs as between Windows and non-Windows builds.
+-- This is the non-Windows version.
+module PathAbsExamples
+  ( pathAbsDirExample
+  , pathAbsFileExample
+  , pathAbsFileExamples
+  ) where
+
+import           Path ( Abs, Dir, File, Path, absdir, absfile )
+
+pathAbsDirExample :: Path Abs Dir
+pathAbsDirExample = [absdir|/home/jane/my-project-dir|]
+
+pathAbsFileExample :: Path Abs File
+pathAbsFileExample = [absfile|/home/jane/my-project-dir/example.ext|]
+
+pathAbsFileExamples :: [Path Abs File]
+pathAbsFileExamples =
+  [ [absfile|/home/jane/my-project-dir/example1.ext|]
+  , [absfile|/home/jane/my-project-dir/example2.ext|]
+  , [absfile|/home/jane/my-project-dir/example3.ext|]
+  ]

--- a/app/test-pretty-exceptions/unix/System/Terminal.hsc
+++ b/app/test-pretty-exceptions/unix/System/Terminal.hsc
@@ -1,0 +1,46 @@
+{-# LANGUAGE CApiFFI #-}
+
+-- | The module of this name differs as between Windows and non-Windows builds.
+-- This is the non-Windows version.
+module System.Terminal
+( getTerminalWidth
+, hIsTerminalDeviceOrMinTTY
+) where
+
+import           Foreign
+import           Foreign.C.Types
+import           RIO (MonadIO, Handle, hIsTerminalDevice)
+
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+
+newtype WindowWidth = WindowWidth CUShort
+    deriving (Eq, Ord, Show)
+
+instance Storable WindowWidth where
+  sizeOf _ = (#size struct winsize)
+  alignment _ = (#alignment struct winsize)
+  peek p = WindowWidth <$> (#peek struct winsize, ws_col) p
+  poke p (WindowWidth w) = do
+    (#poke struct winsize, ws_col) p w
+
+-- `ioctl` is variadic, so `capi` is needed, see:
+-- https://www.haskell.org/ghc/blog/20210709-capi-usage.html
+foreign import capi "sys/ioctl.h ioctl"
+  ioctl :: CInt -> CInt -> Ptr WindowWidth -> IO CInt
+
+getTerminalWidth :: IO (Maybe Int)
+getTerminalWidth =
+  alloca $ \p -> do
+    errno <- ioctl (#const STDOUT_FILENO) (#const TIOCGWINSZ) p
+    if errno < 0
+    then return Nothing
+    else do
+      WindowWidth w <- peek p
+      return . Just . fromIntegral $ w
+
+-- | hIsTerminaDevice does not recognise handles to mintty terminals as terminal
+-- devices, but isMinTTYHandle does.
+hIsTerminalDeviceOrMinTTY :: MonadIO m => Handle -> m Bool
+hIsTerminalDeviceOrMinTTY = hIsTerminalDevice

--- a/app/test-pretty-exceptions/windows/PathAbsExamples.hs
+++ b/app/test-pretty-exceptions/windows/PathAbsExamples.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | The module of this name differs as between Windows and non-Windows builds.
+-- This is the Windows version.
+module PathAbsExamples
+ ( pathAbsDirExample
+ , pathAbsFileExample
+ , pathAbsFileExamples
+ ) where
+
+import           Path ( Abs, Dir, File, Path, absdir, absfile )
+
+pathAbsDirExample :: Path Abs Dir
+pathAbsDirExample = [absdir|C:/Users/jane/my-project-dir|]
+
+pathAbsFileExample :: Path Abs File
+pathAbsFileExample = [absfile|C:/Users/jane/my-project-dir/example.ext|]
+
+pathAbsFileExamples :: [Path Abs File]
+pathAbsFileExamples =
+  [ [absfile|C:/Users/jane/my-project-dir/example1.ext|]
+  , [absfile|C:/Users/jane/my-project-dir/example2.ext|]
+  , [absfile|C:/Users/jane/my-project-dir/example3.ext|]
+  ]

--- a/app/test-pretty-exceptions/windows/System/Terminal.hs
+++ b/app/test-pretty-exceptions/windows/System/Terminal.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE NoImplicitPrelude        #-}
+{-# LANGUAGE OverloadedStrings        #-}
+
+-- | The module of this name differs as between Windows and non-Windows builds.
+-- This is the Windows version.
+module System.Terminal
+  ( getTerminalWidth
+  , hIsTerminalDeviceOrMinTTY
+  ) where
+
+import           Foreign.Marshal.Alloc ( allocaBytes )
+import           Foreign.Ptr ( Ptr )
+import           Foreign.Storable ( peekByteOff )
+import           RIO
+import           RIO.Partial ( read )
+import           System.IO hiding ( hIsTerminalDevice )
+import           System.Process
+                   ( StdStream (..), createProcess, shell, std_err, std_in
+                   , std_out, waitForProcess
+                   )
+import           System.Win32 ( isMinTTYHandle, withHandleToHANDLE )
+
+type HANDLE = Ptr ()
+
+data CONSOLE_SCREEN_BUFFER_INFO
+
+sizeCONSOLE_SCREEN_BUFFER_INFO :: Int
+sizeCONSOLE_SCREEN_BUFFER_INFO = 22
+
+posCONSOLE_SCREEN_BUFFER_INFO_srWindow :: Int
+posCONSOLE_SCREEN_BUFFER_INFO_srWindow = 10 -- 4 x Word16 Left,Top,Right,Bottom
+
+c_STD_OUTPUT_HANDLE :: Int
+c_STD_OUTPUT_HANDLE = -11
+
+foreign import ccall unsafe "windows.h GetConsoleScreenBufferInfo"
+  c_GetConsoleScreenBufferInfo :: HANDLE -> Ptr CONSOLE_SCREEN_BUFFER_INFO -> IO Bool
+
+foreign import ccall unsafe "windows.h GetStdHandle"
+  c_GetStdHandle :: Int -> IO HANDLE
+
+
+getTerminalWidth :: IO (Maybe Int)
+getTerminalWidth = do
+  hdl <- c_GetStdHandle c_STD_OUTPUT_HANDLE
+  allocaBytes sizeCONSOLE_SCREEN_BUFFER_INFO $ \p -> do
+    b <- c_GetConsoleScreenBufferInfo hdl p
+    if not b
+      then do -- This could happen on Cygwin or MSYS
+        let stty = (shell "stty size") {
+              std_in  = UseHandle stdin
+            , std_out = CreatePipe
+            , std_err = CreatePipe
+            }
+        (_, mbStdout, _, rStty) <- createProcess stty
+        exStty <- waitForProcess rStty
+        case exStty of
+          ExitFailure _ -> pure Nothing
+          ExitSuccess ->
+            maybe (pure Nothing)
+                  (\hSize -> do
+                      sizeStr <- hGetContents hSize
+                      case map read $ words sizeStr :: [Int] of
+                        [_r, c] -> pure $ Just c
+                        _ -> pure Nothing
+                  )
+                  mbStdout
+      else do
+        [left,_top,right,_bottom] <- forM [0..3] $ \i -> do
+          v <- peekByteOff p (i * 2 + posCONSOLE_SCREEN_BUFFER_INFO_srWindow)
+          pure $ fromIntegral (v :: Word16)
+        pure $ Just (1 + right - left)
+
+-- | hIsTerminaDevice does not recognise handles to mintty terminals as terminal
+-- devices, but isMinTTYHandle does.
+hIsTerminalDeviceOrMinTTY :: MonadIO m => Handle -> m Bool
+hIsTerminalDeviceOrMinTTY h = do
+  isTD <- hIsTerminalDevice h
+  if isTD
+    then pure True
+    else liftIO $ withHandleToHANDLE h isMinTTYHandle

--- a/package.yaml
+++ b/package.yaml
@@ -16,53 +16,59 @@ extra-source-files:
 - attic/package-0.1.2.3.tar.gz
 - attic/symlink-to-dir.tar.gz
 
+flags:
+  test-pretty-exceptions:
+    description: Build an executable to test pretty exceptions
+    default: false
+    manual: false
+
 dependencies:
 - base >=4.10 && < 5
-- ansi-terminal
-- digest
-- rio
 - aeson
-- text
-- unordered-containers
-- containers
-- path
-- transformers
-- generic-deriving
-- unliftio
-- http-conduit
-- http-client-tls
-- http-download
-- http-types
-- http-client
-- conduit
+- ansi-terminal
 - bytestring
-- network-uri
-- hackage-security
-- primitive
-- vector
-- memory
+- Cabal >= 3 && < 3.11
+- casa-client
+- casa-types
+- conduit
+- conduit-extra
+- containers
 - cryptonite
 - cryptonite-conduit
+- digest
+- filelock
+- generic-deriving
+- hackage-security
+- hpack >= 0.35.1
+- http-client
+- http-client-tls
+- http-conduit
+- http-download
+- http-types
+- memory
+- mtl
+- network-uri
+- path
+- path-io
 - persistent
 - persistent-sqlite >= 2.9.3
 - persistent-template
-- Cabal >= 3 && < 3.11
-- path-io
+- primitive
+- resourcet
+- rio
 - rio-orphans
-- conduit-extra
+- rio-prettyprint
 - tar-conduit
+- text
+- text-metrics
 - time
+- transformers
 - unix-compat
-- hpack >= 0.35.1
+- unliftio
+- unordered-containers
+- vector
 - yaml
 - zip-archive
-- text-metrics
-- resourcet
-- rio-prettyprint
-- mtl
-- filelock
-- casa-client
-- casa-types
 
 ghc-options:
   - -Wall
@@ -104,14 +110,33 @@ library:
   - Pantry.Tree
   - Pantry.Types
 
+executables:
+  test-pretty-exceptions:
+    when:
+    - condition: "!flag(test-pretty-exceptions)"
+      buildable: false
+    - condition: 'os(windows)'
+      then:
+        source-dirs: app/test-pretty-exceptions/windows/
+        dependencies:
+        - process
+        - Win32
+      else:
+        source-dirs: app/test-pretty-exceptions/unix/
+    main: Main.hs
+    source-dirs: app/test-pretty-exceptions
+    dependencies:
+    - pantry
+    - optparse-applicative
+
 tests:
   spec:
     source-dirs: test
     main: Spec.hs
     dependencies:
     - pantry
-    - hspec
     - exceptions
     - hedgehog
+    - hspec
     - QuickCheck
     - raw-strings-qq

--- a/pantry.cabal
+++ b/pantry.cabal
@@ -28,6 +28,11 @@ source-repository head
   type: git
   location: https://github.com/commercialhaskell/pantry
 
+flag test-pretty-exceptions
+  description: Build an executable to test pretty exceptions
+  manual: False
+  default: False
+
 library
   exposed-modules:
       Pantry
@@ -110,6 +115,81 @@ library
         System.IsWindows
     hs-source-dirs:
         src/unix/
+
+executable test-pretty-exceptions
+  main-is: Main.hs
+  other-modules:
+      Paths_pantry
+  hs-source-dirs:
+      app/test-pretty-exceptions
+  ghc-options: -Wall
+  build-depends:
+      Cabal >=3 && <3.11
+    , aeson
+    , ansi-terminal
+    , base >=4.10 && <5
+    , bytestring
+    , casa-client
+    , casa-types
+    , conduit
+    , conduit-extra
+    , containers
+    , cryptonite
+    , cryptonite-conduit
+    , digest
+    , filelock
+    , generic-deriving
+    , hackage-security
+    , hpack >=0.35.1
+    , http-client
+    , http-client-tls
+    , http-conduit
+    , http-download
+    , http-types
+    , memory
+    , mtl
+    , network-uri
+    , optparse-applicative
+    , pantry
+    , path
+    , path-io
+    , persistent
+    , persistent-sqlite >=2.9.3
+    , persistent-template
+    , primitive
+    , resourcet
+    , rio
+    , rio-orphans
+    , rio-prettyprint
+    , tar-conduit
+    , text
+    , text-metrics
+    , time
+    , transformers
+    , unix-compat
+    , unliftio
+    , unordered-containers
+    , vector
+    , yaml
+    , zip-archive
+  default-language: Haskell2010
+  if !flag(test-pretty-exceptions)
+    buildable: False
+  if os(windows)
+    other-modules:
+        PathAbsExamples
+        System.Terminal
+    hs-source-dirs:
+        app/test-pretty-exceptions/windows/
+    build-depends:
+        Win32
+      , process
+  else
+    other-modules:
+        PathAbsExamples
+        System.Terminal
+    hs-source-dirs:
+        app/test-pretty-exceptions/unix/
 
 test-suite spec
   type: exitcode-stdio-1.0


### PR DESCRIPTION
This adds an optional executable `test-pretty-exceptions` (it is only built if flag `test-pretty-exceptions` is set; unset by default) to allow a person to test in a terminal (by visual inspection) the form of Pantry's pretty exceptions. The test is implemented as an executable rather than a 'test', because it is intended to be used by a person, not built and run automatically as part of CI, like a 'test' would.

Tested by building and running on Windows 11 and macOS 13.1. The CI has been extended to test the buildng of the executable.