### PR TITLE
Re Stack #6114 add error S-395 (`NoLocalPackageDirFound`)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for pantry
 
+## v0.8.2.2
+
+* Add error S-395 (`NoLocalPackageDirFound`).
+
 ## v0.8.2.1
 
 * On Windows, avoid fatal `tar: Cannot connect to C: resolve failed` bug when

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        pantry
-version:     0.8.2.1
+version:     0.8.2.2
 synopsis:    Content addressable Haskell package management
 description: Please see the README on GitHub at <https://github.com/commercialhaskell/pantry#readme>
 category:    Development

--- a/pantry.cabal
+++ b/pantry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           pantry
-version:        0.8.2.1
+version:        0.8.2.2
 synopsis:       Content addressable Haskell package management
 description:    Please see the README on GitHub at <https://github.com/commercialhaskell/pantry#readme>
 category:       Development

--- a/src/Pantry/Types.hs
+++ b/src/Pantry/Types.hs
@@ -966,6 +966,7 @@ data PantryException
   | TreeWithoutCabalFile !RawPackageLocationImmutable
   | TreeWithMultipleCabalFiles !RawPackageLocationImmutable ![SafeFilePath]
   | MismatchedCabalName !(Path Abs File) !PackageName
+  | NoLocalPackageDirFound !(Path Abs Dir)
   | NoCabalFileFound !(Path Abs Dir)
   | MultipleCabalFilesFound !(Path Abs Dir) ![Path Abs File]
   | InvalidWantedCompiler !Text
@@ -1086,6 +1087,15 @@ instance Display PantryException where
     <> ".cabal\n"
     <> "Hackage rejects packages where the first part of the Cabal file name "
     <> "is not the package name."
+  display (NoLocalPackageDirFound dir) =
+    "Error: [S-395]\n"
+    <> "Stack looks for packages in the directories configured in\n"
+    <> "the 'packages' and 'extra-deps' fields defined in your stack.yaml\n"
+    <> "The current entry points to "
+    <> fromString (toFilePath dir)
+    <> ",\nbut no such directory could be found. If, alternatively, a package\n"
+    <> "in the package index was intended, its name and version must be\n"
+    <> "specified as an extra-dep."
   display (NoCabalFileFound dir) =
     "Error: [S-636]\n"
     <> "Stack looks for packages in the directories configured in\n"
@@ -1421,6 +1431,22 @@ instance Pretty PantryException where
          , style File (fromString $ packageNameString name <> ".cabal") <> "."
          , flow "Hackage rejects packages where the first part of the Cabal"
          , flow "file name is not the package name."
+         ]
+  pretty (NoLocalPackageDirFound dir) =
+    "[S-395]"
+    <> line
+    <> fillSep
+         [ flow "Stack looks for packages in the directories configured in the"
+         , style Shell "packages"
+         , "and"
+         , style Shell "extra-deps"
+         , flow "fields defined in your"
+         , style File "stack.yaml" <> "."
+         , flow "The current entry points to"
+         , pretty dir
+         , flow "but no such directory could be found. If, alternatively, a"
+         , flow "package in the package index was intended, its name and"
+         , flow "version must be specified as an extra-dep."
          ]
   pretty (NoCabalFileFound dir) =
     "[S-636]"


### PR DESCRIPTION
Tested by building and using Stack with the dependency, on Windows.