### PR TITLE
Apply certain Hlint suggestions

### DIFF
--- a/src/Hackage/Security/Client/Repository/HttpLib/HttpClient.hs
+++ b/src/Hackage/Security/Client/Repository/HttpLib/HttpClient.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE OverloadedStrings   #-}
 
 -- Adapted from `hackage-security-http-client` to use our own
 -- `Pantry.HTTP` implementation
@@ -76,7 +75,7 @@ getRange reqHeaders uri (from, to) callback = wrapCustomEx $ do
 -- but it is currently disabled <https://github.com/snoyberg/http-client/issues/116>
 wrapCustomEx :: (Throws HTTP.HttpException => IO a)
              -> (Throws SomeRemoteError => IO a)
-wrapCustomEx act = handleChecked (\(ex :: HTTP.HttpException) -> go ex) act
+wrapCustomEx = handleChecked (\(ex :: HTTP.HttpException) -> go ex)
   where
     go ex = throwChecked (SomeRemoteError ex)
 
@@ -142,10 +141,7 @@ setRequestHeaders opts =
 
 -- | Extract the response headers
 getResponseHeaders :: HTTP.Response a -> [HttpResponseHeader]
-getResponseHeaders response = concat [
-      [ HttpResponseAcceptRangesBytes
-      | (hAcceptRanges, "bytes") `elem` headers
-      ]
-    ]
-  where
-    headers = HTTP.getResponseHeaders response
+getResponseHeaders response =
+  [ HttpResponseAcceptRangesBytes | (hAcceptRanges, "bytes") `elem` headers ]
+ where
+  headers = HTTP.getResponseHeaders response

--- a/src/Pantry/Casa.hs
+++ b/src/Pantry/Casa.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
 
 -- | Integration with the Casa server.

--- a/src/Pantry/HTTP.hs
+++ b/src/Pantry/HTTP.hs
@@ -8,9 +8,10 @@ module Pantry.HTTP
   ) where
 
 import           Conduit
-import           Network.HTTP.Client          as Export (parseRequest)
-import           Network.HTTP.Client          as Export (parseUrlThrow)
-import           Network.HTTP.Client          as Export (BodyReader, HttpExceptionContent (StatusCodeException))
+import           Network.HTTP.Client          as Export (BodyReader,
+                                                         HttpExceptionContent (StatusCodeException),
+                                                         parseRequest,
+                                                         parseUrlThrow)
 import qualified Network.HTTP.Client          as HTTP (withResponse)
 import           Network.HTTP.Client.Internal as Export (setUri)
 import           Network.HTTP.Client.TLS      (getGlobalManager)
@@ -51,7 +52,7 @@ httpSink
   => Request
   -> (Response () -> ConduitT ByteString Void m a)
   -> m a
-httpSink req inner = HTTP.httpSink (setUserAgent req) inner
+httpSink req = HTTP.httpSink (setUserAgent req)
 
 httpSinkChecked
   :: MonadUnliftIO m

--- a/src/Pantry/Internal/AesonExtended.hs
+++ b/src/Pantry/Internal/AesonExtended.hs
@@ -93,7 +93,7 @@ wp ..!= d =
             fmap (, a) (fmap fst p .!= d)
 
 presentCount :: Object -> [Text] -> Int
-presentCount o ss = length . filter (\x -> HashMap.member (textToKey x) o) $ ss
+presentCount o = length . filter (\x -> HashMap.member (textToKey x) o)
 
 -- | Synonym version of @..:@.
 (...:) :: FromJSON a => Object -> [Text] -> WarningParser a

--- a/src/Pantry/Internal/StaticBytes.hs
+++ b/src/Pantry/Internal/StaticBytes.hs
@@ -106,7 +106,7 @@ withPeekForeign (fptr, off, len) inner =
 
 instance DynamicBytes B.ByteString where
   lengthD = B.length
-  fromWordsD = fromWordsForeign (\fptr len -> B.fromForeignPtr fptr 0 len)
+  fromWordsD = fromWordsForeign (`B.fromForeignPtr` 0)
   withPeekD = withPeekForeign . B.toForeignPtr
 
 instance word8 ~ Word8 => DynamicBytes (VS.Vector word8) where

--- a/src/Pantry/Tree.hs
+++ b/src/Pantry/Tree.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 module Pantry.Tree
   ( unpackTree
@@ -14,11 +13,10 @@ import Pantry.Storage hiding (Tree, TreeEntry, findOrGenerateCabalFile)
 import Pantry.Types
 import RIO.FilePath ((</>), takeDirectory)
 import RIO.Directory (createDirectoryIfMissing, setPermissions, getPermissions, setOwnerExecutable)
-import Path (Path, Abs, Dir, toFilePath)
+import Path (Abs, Dir, File, Path, toFilePath)
 import Distribution.Parsec (PWarning (..))
 import Distribution.PackageDescription (GenericPackageDescription)
 import Distribution.PackageDescription.Parsec
-import Path (File)
 
 unpackTree
   :: (HasPantryConfig env, HasLogFunc env)


### PR DESCRIPTION
I went through the Hlint suggestions and applied those that seemed to be either sensible or, at least, not objectionable.

I hesitated over, but ultimately accepted:

*   'hoist not' (see also https://www.reddit.com/r/haskell/comments/z86sa2/why_is_hoisting_not_better/)

    ~~~haskell
    guard $ all (not . T.all (== '.')) $ T.split (== '/') t -- Original
    guard $ (not . any (T.all (== '.'))) $ T.split (== '/') t -- Suggestion
    ~~~

*   The use of infix and sections with a function with more than two arguments:

    ~~~haskell
    fromWordsD = fromWordsForeign (\fptr len -> B.fromForeignPtr fptr 0 len) -- Original
    fromWordsD = fromWordsForeign (`B.fromForeignPtr` 0) -- Suggestion
    ~~~