### PR TITLE
Add build-tool: hspec-discover

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -136,6 +136,7 @@ executables:
 
 tests:
   spec:
+    build-tools: hspec-discover
     source-dirs: test
     main: Spec.hs
     dependencies:

--- a/pantry.cabal
+++ b/pantry.cabal
@@ -216,6 +216,8 @@ test-suite spec
   hs-source-dirs:
       test
   ghc-options: -Wall
+  build-tool-depends:
+      hspec-discover:hspec-discover
   build-depends:
       Cabal >=3 && <3.11
     , QuickCheck


### PR DESCRIPTION
Fixes `could not execute: hspec-discover`:

```
$ cabal build all --enable-tests --enable-benchmarks
Build profile: -w ghc-9.4.5 -O1
In order, the following will be built (use -v for more details):
 - pantry-0.8.3 (lib) (configuration changed)
 - pantry-0.8.3 (test:spec) (first run)
Configuring library for pantry-0.8.3..
Preprocessing library for pantry-0.8.3..
Building library for pantry-0.8.3..
[18 of 19] Compiling Pantry.Repo
src/Pantry/Repo.hs:299:46: warning: [-Wdeprecations]
    In the use of ‘hSupportsANSIWithoutEmulation’
    (imported from System.Console.ANSI):
    Deprecated: "See Haddock documentation and hSupportsANSI."
    |
299 |           when osIsWindows $ void $ liftIO $ hSupportsANSIWithoutEmulation stdout
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[19 of 19] Compiling Pantry
Configuring test suite 'spec' for pantry-0.8.3..
Preprocessing test suite 'spec' for pantry-0.8.3..
Building test suite 'spec' for pantry-0.8.3..
ghc-9.4.5: could not execute: hspec-discover
Error: cabal: Failed to build test:spec from pantry-0.8.3.
```

See https://github.com/sol/hpack/issues/254 and `build-tools` in [hpack common fields](https://github.com/sol/hpack#common-fields).
