### PR TITLE
Fix #129 `loadRawPackage` works with submodules in PowerShell

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for pantry
 
+## v0.9.3.3
+
+* `loadPackageRaw` supports cloning of repositories with submodules in
+  PowerShell.
+* Drop support for `git` versions before 2.11.0.
+
 ## v0.9.3.2
 
 * Support `ansi-terminal-1.0.2`.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: pantry
-version: 0.9.3.2
+version: 0.9.3.3
 synopsis: Content addressable Haskell package management
 description: Please see the README on GitHub at <https://github.com/commercialhaskell/pantry#readme>
 category: Development

--- a/pantry.cabal
+++ b/pantry.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           pantry
-version:        0.9.3.2
+version:        0.9.3.3
 synopsis:       Content addressable Haskell package management
 description:    Please see the README on GitHub at <https://github.com/commercialhaskell/pantry#readme>
 category:       Development


### PR DESCRIPTION
Currently testing with a modified version of Stack.

Outside of the `git submodule foreach` environment, the `tar` on Windows outside of Stack's environment is likely `bsdtar`. `Stack.SetupCmd.setupCmd` uses `withBuildConfig` not `withDefaultEnvConfig`.