### PR TITLE
Root key update 2025-07

### DIFF
--- a/int/Pantry/Types.hs
+++ b/int/Pantry/Types.hs
@@ -782,8 +782,6 @@ defaultHackageSecurityConfig = HackageSecurityConfig
         "0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d"
       , -- Norman Ramsey (ZI8di3a9Un0s2RBrt5GwVRvfOXVuywADfXGPZfkiDb0=)
         "51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921"
-      , -- Mathieu Boespflug (ydN1nGGQ79K1Q0nN+ul+Ln8MxikTB95w0YdGd3v3kmg=)
-        "be75553f3c7ba1dbe298da81f1d1b05c9d39dd8ed2616c9bddf1525ca8c03e48"
       , -- Joachim Breitner (5iUgwqZCWrCJktqMx0bBMIuoIyT4A1RYGozzchRN9rA=)
         "d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522"
       ]

--- a/int/Pantry/Types.hs
+++ b/int/Pantry/Types.hs
@@ -784,6 +784,8 @@ defaultHackageSecurityConfig = HackageSecurityConfig
         "51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921"
       , -- Joachim Breitner (5iUgwqZCWrCJktqMx0bBMIuoIyT4A1RYGozzchRN9rA=)
         "d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522"
+      , -- Tikhon Jelvis (06nM6r1kOYt49YE5e1+j8VKiiYUFjFQ6HrOpPZu+fDE=)
+        "c7de58fc6a224b92b5b513f26fbb8b370f2d97c7cfe0075a951314a55734be93"
       ]
   , hscKeyThreshold = 3
   , hscIgnoreExpiry = True


### PR DESCRIPTION
Mathieu is no longer serving as a root key holder, and we have added Tikhon.

The new root key is authorized by the existing keyholders, so existing clients should give them the proper authority. However, new clients should have the current set of keyholders in the bootstrap set, which makes the system more robust against people leaving the process.

These changes remove the obsolete key, add the new key. Please check the keys against https://github.com/haskell-infra/hackage-root-keys before merging.

Please see https://github.com/commercialhaskell/pantry/pull/94 for a prior PR in the same vein.